### PR TITLE
fix CommonJS build

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -119,8 +119,6 @@ Test if `input` can be bumped without rejection.
 
 Conform to same API as `Bumpover`, with its `bump` method receives and yields XML string.
 
-> Please install `xml-js` to use `XMLBumpover`.
-
 
 ## `JSONBumpover`
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -130,15 +130,7 @@ This allows easier data validity checking with rules.
 
 ## Bumping XML String
 
-Besides plain JavaScript object, transforming XML string is also trivial for bumpover. To do this we'll add dependency first:
-
-```
-npm install --save xml-js
-```
-
-> `xml-js` is not a peer dependency of bumpover, but it's required when bumping XML.
-
-Then import `XMLBumpover`, which extends `Bumpover` under the hood.
+Besides plain JavaScript object, transforming XML string is also trivial for bumpover. To do this simply import `XMLBumpover`, which extends `Bumpover` under the hood.
 
 ``` js
 import { XMLBumpover } from 'bumpover'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
       "test/**/*.js"
     ]
   },
+  "dependencies": {
+    "xml-js": "^1.6.1",
+    "superstruct": "^0.5.0"
+  },
   "devDependencies": {
     "ava": "^0.24.0",
     "babel-cli": "^6.26.0",
@@ -57,9 +61,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "standard": "^10.0.3",
-    "superstruct": "^0.5.0",
-    "uglify-es": "^3.3.4",
-    "xml-js": "^1.6.1"
+    "uglify-es": "^3.3.4"
   },
   "peerDependencies": {
     "superstruct": "^0.5.0"


### PR DESCRIPTION
Closes #28 

This PR moves `xml-js` and `superstruct` as dependencies.